### PR TITLE
remove sphinx version constraint

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=5.0,<6.0
+sphinx
 pydata-sphinx-theme
 myst-parser
 numpydoc


### PR DESCRIPTION
Constraining Sphinx to <6 is no longer needed after switching to the v2 docs deployment workflow.