### PR TITLE
Replaced ProxyCommand with ProxyJump is ssh config

### DIFF
--- a/docs/source/programming/SSH-SWC-cluster.md
+++ b/docs/source/programming/SSH-SWC-cluster.md
@@ -131,7 +131,7 @@ Host swc-bastion
 Host swc-gateway
     HostName hpc-gw1
     User <SWC-USERNAME>
-    ProxyCommand ssh -W %h:%p swc-bastion
+    ProxyJump swc-bastion
 ```
 
 Save the file by pressing `Ctrl+O`, then `Enter`.
@@ -223,7 +223,7 @@ Host swc-bastion
 Host swc-gateway
     HostName hpc-gw1
     User <SWC-USERNAME>
-    ProxyCommand ssh -W %h:%p swc-bastion
+    ProxyJump swc-bastion
     IdentityFile ~/.ssh/<MY-SPECIAL-KEY>
 ```
 :::

--- a/docs/source/programming/SSH-vscode.md
+++ b/docs/source/programming/SSH-vscode.md
@@ -13,7 +13,7 @@ Host jump-host
 Host remote-host
     User remoteMachineUsername
     HostName 172.24.243.000
-    ProxyCommand ssh -W %h:%p jump-host
+    ProxyJump jump-host
 ```
 
 Make sure to replace `172.24.243.000` with the IP address of your remote machine.


### PR DESCRIPTION
`ProxyJump` is more explicit and readable. It's also harder to mistype the command