### PR TITLE
Remove show prev / next footer.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,6 +131,7 @@ html_theme_options = {
     },
     "footer_start": ["footer_start"],
     "footer_end": ["footer_end"],
+    "show_prev_next": False
 }
 
 # Hide the "Show Source" button


### PR DESCRIPTION
This PR removes the show / hide next page footer as discussed in #54. This however can be useful if having many sequential pages so we may want to add it back in future if we add more things or the structure changes.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
