### PR TITLE
Fix bug in pooch example

### DIFF
--- a/docs/source/open_science/GIN-repositories.md
+++ b/docs/source/open_science/GIN-repositories.md
@@ -295,12 +295,13 @@ Here is a simple example of how to download a dataset from a GIN repository usin
 import pooch
 
 filepath = pooch.retrieve(
-    url="https://gin.g-node.org/<username>/<repository>/src/main/file",
+    url="https://gin.g-node.org/<username>/raw/<repository>/main/file",
     known_hash=None,
     path="/home/<user>/downloads", # this is where the file will be saved
     progressbar=True,
 )
 ```
+
 
 ## Some under-the-hood details
 

--- a/docs/source/open_science/GIN-repositories.md
+++ b/docs/source/open_science/GIN-repositories.md
@@ -295,7 +295,7 @@ Here is a simple example of how to download a dataset from a GIN repository usin
 import pooch
 
 filepath = pooch.retrieve(
-    url="https://gin.g-node.org/<username>/raw/<repository>/main/file",
+    url="https://gin.g-node.org/<username>/<repository>/raw/main/file",
     known_hash=None,
     path="/home/<user>/downloads", # this is where the file will be saved
     progressbar=True,


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`pooch` example is wrong AFAICT: it will download the GIN website contents showing `file`, not the contents of `file`.

**What does this PR do?**
Specifies the URL correctly in the `pooch` with GIN example.

## References

\

## How has this PR been tested?

These fixtures work as expected (but the commented out line doesnt!)

```python
@pytest.fixture(autouse=True, scope="session")
def brainglobe_test_registry():
    test_data = pooch.create(
        # Use the default cache folder for the operating system
        path=pooch.os_cache("brainglobe_test_data"),
        base_url="https://gin.g-node.org/BrainGlobe/test-data/raw/master/",
#      base_url="https://gin.g-node.org/BrainGlobe/test-data/src/master/",
        # The registry specifies the files that can be fetched
        registry={
            "cellfinder/cells-z-1000-1050.xml": None,
            "cellfinder/other-cells-z-1000-1050.xml": None,
        },
    )
    return test_data

@pytest.fixture
def cells(brainglobe_test_registry):
    cell_data_path = brainglobe_test_registry.fetch("cellfinder/cells-z-1000-1050.xml")
    cell_data = get_cells(cell_data_path)
    return cell_data
```

## Is this a breaking change?

\

## Does this PR require an update to the documentation?

This is an update to the documentation.

## Checklist:

- [x] The code has been tested locally
- [\] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
