### PR TITLE
Remove mentions of `fast` partition

### DIFF
--- a/docs/source/data_analysis/HPC-module-SLEAP.md
+++ b/docs/source/data_analysis/HPC-module-SLEAP.md
@@ -488,19 +488,19 @@ Login to the HPC cluster as described [above](access-to-the-hpc-cluster).
 Start an interactive job on a GPU node. This step is necessary, because we need
 to test the module's access to the GPU.
 ```{code-block} console
-$ srun -p fast --gres=gpu:1 --pty bash -i
+$ srun -p gpu --gres=gpu:1 --pty bash -i
 ```
 :::{dropdown} Explain the above command
 :color: info
 :icon: info
 
-* `-p fast` requests a node from the 'fast' partition. This refers to the queue of nodes with a 3-hour time limit. They are meant for short jobs, such as testing.
+* `-p gpu` requests a node from the 'gpu' partition (queue)
 * `--gres=gpu:1` requests 1 GPU of any kind
-*  `--pty` is short for 'pseudo-terminal'.
+*  `--pty` is short for 'pseudo-terminal'
 *  The `-i` stands for 'interactive'
 
 Taken together, the above command will start an interactive bash terminal session
-on a node of the 'fast' partition, equipped with 1 GPU.
+on a node of the 'gpu' partition, equipped with 1 GPU card.
 :::
 
 First, let's verify that you are indeed on a node equipped with a functional

--- a/docs/source/programming/SLURM-arguments.md
+++ b/docs/source/programming/SLURM-arguments.md
@@ -54,7 +54,7 @@ For a more detailed description see the [SLURM documentation](https://slurm.sche
 - *Name:* `--partition`
 - *Alias:* `-p`
 - *Description:* Specifies the partition (or queue) to submit the job to. To see a list of all partitions/queues, the nodes they contain and their respective time limits, type `sinfo` when logged in to the HPC cluster.
-- *Example values:* `gpu`, `cpu`, `fast`, `medium`
+- *Example values:* `gpu`, `cpu`
 
 ### Job Name
 - *Name:* `--job-name`

--- a/docs/source/programming/SSH-SWC-cluster.md
+++ b/docs/source/programming/SSH-SWC-cluster.md
@@ -115,6 +115,10 @@ $ conda create -n myenv python=3.10
 
 The first command requests 4 cores and 8GB of memory on a node of the `cpu`
 partition, meant for jobs that do not require GPUs.
+Depending on your needs and node availability, you may need to request
+a different partition. See the [SLURM arguments primer](slurm-arguments-target)
+for more information.
+
 The `--pty bash -i` part specifies
 an interactive bash shell. The following two commands are run in this shell,
 on the assigned *compute* node.

--- a/docs/source/programming/SSH-SWC-cluster.md
+++ b/docs/source/programming/SSH-SWC-cluster.md
@@ -108,13 +108,14 @@ request an interactive session on a *compute* node using the `srun` command.
 Here's an example for creating a new conda environment:
 
 ```{code-block} console
-$ srun -p fast -n 4 --mem 8G --pty bash -i
+$ srun -p cpu -n 4 --mem 8G --pty bash -i
 $ module load miniconda
 $ conda create -n myenv python=3.10
 ```
 
-The first command requests 4 cores and 8GB of memory on a node of the `fast`
-partition, meant for jobs up to 3 hours long. The `--pty bash -i` part specifies
+The first command requests 4 cores and 8GB of memory on a node of the `cpu`
+partition, meant for jobs that do not require GPUs.
+The `--pty bash -i` part specifies
 an interactive bash shell. The following two commands are run in this shell,
 on the assigned *compute* node.
 

--- a/docs/source/programming/vscode-with-slurm-job.md
+++ b/docs/source/programming/vscode-with-slurm-job.md
@@ -22,7 +22,9 @@ Once connected, request an interactive job via SLURM to access a compute node. F
 $ srun -p cpu -n 4 --mem 8G --pty bash -i
 ```
 
-In this example, `-p cpu` requests the 'cpu' partition, with default time settings, though you may adjust this according to your needs. For more information, see the [SLURM arguments primer](https://howto.neuroinformatics.dev/programming/SLURM-arguments.html).
+In this example, `-p cpu` requests the "cpu" partition, with default time settings, though you may adjust this according to your needs.
+You can also try other partitions depending on your needs and node availability.
+For more information, see the [SLURM arguments primer](slurm-arguments-target).
 
 After connecting to a compute node, initiate [VSCode Remote Tunnel](https://code.visualstudio.com/docs/remote/tunnels) by typing:
 

--- a/docs/source/programming/vscode-with-slurm-job.md
+++ b/docs/source/programming/vscode-with-slurm-job.md
@@ -19,10 +19,10 @@ $ ssh hpc-gw2
 Once connected, request an interactive job via SLURM to access a compute node. For example:
 
 ```{code-block} console
-$ srun -p fast -n 4 --mem 8G --pty bash -i
+$ srun -p cpu -n 4 --mem 8G --pty bash -i
 ```
 
-In this example, `-p fast` requests the fast partition, with default time settings, though you may adjust this according to your needs. For more information, see the [SLURM arguments primer](https://howto.neuroinformatics.dev/programming/SLURM-arguments.html).
+In this example, `-p cpu` requests the 'cpu' partition, with default time settings, though you may adjust this according to your needs. For more information, see the [SLURM arguments primer](https://howto.neuroinformatics.dev/programming/SLURM-arguments.html).
 
 After connecting to a compute node, initiate [VSCode Remote Tunnel](https://code.visualstudio.com/docs/remote/tunnels) by typing:
 
@@ -70,6 +70,6 @@ As explained in [VSCode docs](https://code.visualstudio.com/docs/remote/tunnels)
 One advantage of using VSCode's code tunnel is that it forwards any HTTP servers launched from the same node, such as Dash-Plotly apps or Jupyter Notebook servers. To launch your additional server, request a separate slurm job for the same compute node, e.g.:
 
 ```{code-block} console
-$ srun -p fast -w <node-name> -n 4 --mem 8G --pty bash -i
+$ srun -p cpu -w <node-name> -n 4 --mem 8G --pty bash -i
 ```
 When these are initiated, VSCode will notify you with a link that you can follow to access the server's UI directly.


### PR DESCRIPTION
The `fast` and `medium` partitions no longer exist on the updated ubuntu-24 cluster.
I've replaced their mentions with `cpu` or `gpu` depending on the context. I also added some notes cautioning people that they may need to use a different partition depending on needs/availability, redirecting them to the SLURM arguments primer guide.