### PR TITLE
Update swc wiki links

### DIFF
--- a/docs/source/_static/swc-wiki-warning.md
+++ b/docs/source/_static/swc-wiki-warning.md
@@ -1,6 +1,6 @@
 :::{warning}
 Some links within this document point to the
-[SWC internal wiki](https://wiki.ucl.ac.uk/display/SI/SWC+Intranet),
+[SWC internal wiki](https://liveuclac.sharepoint.com/sites/SWCIntranet),
 which is only accessible from within the SWC network.
 We recommend opening these links in a new tab.
 :::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ exclude_patterns = [
 # Ignore certain URLs from being checked
 linkcheck_ignore = [
     "https://neuromorpho.org/",
-    "https://wiki.ucl.ac.uk/",  # ignore everything on the internal wiki
+    "https://liveuclac.sharepoint.com/",  # ignore everything on the internal wiki
     "https://linux.die.net/man/1/rsync",
     "https://www.uclb.com/",
     "https://support.zadarastorage.com",

--- a/docs/source/data_analysis/HPC-module-SLEAP.md
+++ b/docs/source/data_analysis/HPC-module-SLEAP.md
@@ -89,7 +89,7 @@ To minimise the risk of issues due to incompatibilities between versions, ensure
 ### Mount the SWC filesystem on your local PC/laptop
 The rest of this guide assumes that you have mounted the SWC filesystem on your local PC/laptop.
 If you have not done so, please follow the relevant instructions on the
-[SWC internal wiki](https://wiki.ucl.ac.uk/display/SSC/SWC+Storage+Platform+Overview).
+[SWC internal wiki](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-SWC-Storage-Platform-Overview-198905992.aspx).
 
 We will also assume that the data you are working with are stored in a `ceph`
 directory to which you have access to. In the rest of this guide, we will use the path
@@ -341,7 +341,7 @@ $ cat slurm.gpu-sr670-20.3445652.err
 
 If you encounter out-of-memory errors, keep in mind that there two main sources of memory usage:
 - CPU memory (RAM), specified via the `--mem` argument in the SLURM batch script. This is the memory used by the Python process running the training job and is shared among all the CPU cores.
-- GPU memory, this is the memory used by the GPU card(s) and depends on the GPU card type you requested via the `--gres gpu:1` argument in the SLURM batch script. To increase it, you can request a specific GPU card type with more GPU memory (e.g. `--gres gpu:a4500:1`). The SWC wiki provides a [list of all GPU card types and their specifications](https://wiki.ucl.ac.uk/display/SSC/CPU+and+GPU+Platform+architecture).
+- GPU memory, this is the memory used by the GPU card(s) and depends on the GPU card type you requested via the `--gres gpu:1` argument in the SLURM batch script. To increase it, you can request a specific GPU card type with more GPU memory (e.g. `--gres gpu:a4500:1`). The SWC wiki provides a [list of all GPU card types and their specifications](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-CPU-and-GPU-Platform-architecture-165449857.aspx).
 - If requesting more memory doesn't help, you can try reducing the size of your SLEAP models. You may tweak the model backbone architecture, or play with *Input scaling*, *Max stride* and *Batch size*. See SLEAP's [documentation](https://sleap.ai/) and [discussion forum](https://github.com/talmolab/sleap/discussions) for more details.
 ```
 
@@ -439,7 +439,7 @@ sleap-track $VIDEO_DIR/M708149_EPM_20200317_165049331-converted.mp4 \
 The script is very similar to the training script, with the following differences:
 - The time limit `-t` is set lower, since inference is normally faster than training. This will however depend on the size of the video and the number of models used.
 - The requested number of cores `n` and memory `--mem` are higher. This will depend on the requirements of the specific job you are running. It's best practice to try with a scaled-down version of your data first, to get an idea of the resources needed.
-- The requested GPU is of a specific kind (RTX 5000). This will again depend on the requirements of your job, as the different GPU kinds vary in GPU memory size and compute capabilities (see [the SWC wiki](https://wiki.ucl.ac.uk/display/SSC/CPU+and+GPU+Platform+architecture)).
+- The requested GPU is of a specific kind (RTX 5000). This will again depend on the requirements of your job, as the different GPU kinds vary in GPU memory size and compute capabilities (see [the SWC wiki](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-CPU-and-GPU-Platform-architecture-165449857.aspx)).
 - The `./train-script.sh` line is replaced by the `sleap-track` command.
 - The `\` character is used to split the long `sleap-track` command into multiple lines for readability. It is not necessary if the command is written on a single line.
 

--- a/docs/source/programming/SLURM-arguments.md
+++ b/docs/source/programming/SLURM-arguments.md
@@ -105,7 +105,7 @@ If needed, the systems administrator can extend long-running jobs.
 :::{warning}
 No GPU will be allocated to you unless you specify it via the `--gres` argument (even if you are on the 'gpu' partition).
 To request 1 GPU of any kind, use `--gres gpu:1`. To request a specific GPU type, you have to include its name, e.g. `--gres gpu:rtx2080:1`.
-You can view the available GPU types on the [SWC internal wiki](https://wiki.ucl.ac.uk/display/SSC/CPU+and+GPU+Platform+architecture).
+You can view the available GPU types on the [SWC internal wiki](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-CPU-and-GPU-Platform-architecture-165449857.aspx).
 :::
 
 ### Standard Output File

--- a/docs/source/programming/SSH-SWC-cluster.md
+++ b/docs/source/programming/SSH-SWC-cluster.md
@@ -27,7 +27,7 @@ the connection is much more straightforward than described here
 
 ## Prerequisites
 - You have an SWC account and know your username and password.
-- You have read the [SWC wiki's section on High Performance Computing (HPC)](https://wiki.ucl.ac.uk/display/SSC/High+Performance+Computing), especially the [Logging into the Cluster page](https://wiki.ucl.ac.uk/display/SSC/Logging+into+the+Cluster).
+- You have read the [SWC wiki's section on High Performance Computing (HPC)](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-High-Performance-Computing-147954090.aspx), especially the [Logging into the Cluster page](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-Logging-into-the-Cluster-194972967.aspx).
 - You know the basics of using the command line, i.e. using the terminal to navigate the file system and run commands.
 - You have an SSH client installed on your computer. This is usually pre-installed on Linux and macOS. SSH is also available on Windows (since Windows 10), however some steps will differ. If you are a Windows user, read the note below before proceeding.
 
@@ -130,11 +130,11 @@ a Windows or a Linux image. These machines are already part of the SWC's
 trusted network domain, meaning you can access the HPC cluster without
 having to go through the *bastion* node.
 
-- If you are using a [managed Windows desktop](https://wiki.ucl.ac.uk/display/SSC/SWC+Desktops),
+- If you are using a [managed Windows desktop](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-SWC-Desktops-147956857.aspx),
 you can SSH directly into the *gateway* node with `ssh hpc-gw2` from the
 Windows `cmd` or PowerShell.
 You may use that node to prepare your scripts and submit SLURM jobs.
-- If you are using a [managed Linux desktop](https://wiki.ucl.ac.uk/display/SSC/Managed+Linux+Desktop),
+- If you are using a [managed Linux desktop](https://liveuclac.sharepoint.com/sites/SSC/SitePages/SSC-Managed-Linux-Desktop-69502751.aspx),
 you can even bypass the *gateway* node. In fact, you may directly submit SLURM jobs
 from your terminal, without having to SSH at all. That's because managed Linux desktops
 use the same platform as the HPC nodes


### PR DESCRIPTION
Closes #73.

Linkcheck didn't catch this, because we necessarily have to ignore SWC wiki links, as they are only accessible on the internal network.